### PR TITLE
Make the current application work with ruby 1.9.2

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -4,7 +4,7 @@ Bundler.setup
 
 Bundler.require(:runtime)
 
-require 'app'
+require './app'
 
 use Rack::Static, :urls => ["/css", "/images", "/js"], :root => "public"
 


### PR DESCRIPTION
Ruby 1.9.2 doesn't load '.' as an include path.
This commit will append './' before 'app' in config.ru thus making it work with ruby 1.9.2
